### PR TITLE
Agent base class and Tools functions decorators

### DIFF
--- a/aiden_app/agents/agent.py
+++ b/aiden_app/agents/agent.py
@@ -1,0 +1,58 @@
+import json
+from typing import Any, Dict, List, Tuple
+from abc import ABC, abstractmethod
+
+from ..tools.cv_editor_tool import CVEditorTool
+from ..tools.indeed_scraper_tool import IndeedScraperTool
+from ..tools.tool_aggregator import ToolAggregator
+from .prompts import START_CHAT_PROMPT, SYSTEM_PROMPT
+
+
+class Agent(ABC):
+    def __init__(self, profile: Dict[str, Any], message_class: Any):
+        self.tool_aggregator = ToolAggregator(
+            [
+                CVEditorTool(first_name=profile["first_name"], last_name=profile["last_name"]),
+                IndeedScraperTool(),
+            ]
+        )
+        start_messages = [
+            message_class(role="system", content=SYSTEM_PROMPT),
+            message_class(role="system", content=json.dumps(profile)),
+            message_class(role="assistant", content=START_CHAT_PROMPT),
+        ]
+        self.message_class = message_class
+        self.messages: List[Dict[str, Any]] = start_messages
+        self.tokens_used = 0
+        self.max_tool_calls = 5
+        self.profile = profile
+        self.client = None
+
+    @abstractmethod
+    def chat(self, user_input: str) -> Tuple[Dict[str, str], bool]:
+        pass
+
+    @abstractmethod
+    def serialize_messages(self) -> list[Dict[str, str]]:
+        pass
+
+    @abstractmethod
+    def unserialize_messages(self, messages: str) -> None:
+        pass
+
+    def to_json(self) -> str:
+        state = self.__dict__.copy()
+        del state["client"]
+        del state["tool_aggregator"]
+        del state["message_class"]
+        state["messages"] = self.serialize_messages()
+        return json.dumps(state)
+
+    @classmethod
+    def from_json(cls, state: str) -> "Agent":
+        state = json.loads(state)
+        self = cls(state["profile"])
+        self.unserialize_messages(state["messages"])
+        del state["messages"]
+        self.__dict__.update(state)
+        return self

--- a/aiden_app/agents/mistral_agent.py
+++ b/aiden_app/agents/mistral_agent.py
@@ -5,9 +5,6 @@ from mistralai.client import MistralClient
 from mistralai.models.chat_completion import ChatMessage, FunctionCall
 from ..tools.talk_tool import TalkTool
 from .agent import Agent
-from logging import getLogger
-
-logger = getLogger(__name__)
 
 
 class MistralAgent(Agent):
@@ -65,6 +62,6 @@ class MistralAgent(Agent):
                 if not agent_speaks_next:
                     yield tool_message.model_dump(), True
                     return
-                yield tool_message, False
+                yield tool_message.model_dump(), False
             message = self._message_model()
             yield message.model_dump(), is_waiting_for_user_message()

--- a/aiden_app/agents/mistral_agent.py
+++ b/aiden_app/agents/mistral_agent.py
@@ -1,42 +1,38 @@
 import json
 import os
-
+from typing import Union
 from mistralai.client import MistralClient
 from mistralai.models.chat_completion import ChatMessage, FunctionCall
-
-from ..tools.cv_editor_tool import CVEditorTool
-from ..tools.indeed_scraper_tool import IndeedScraperTool
 from ..tools.talk_tool import TalkTool
-from ..tools.tool_aggregator import ToolAggregator
-from .prompts import START_CHAT_PROMPT, SYSTEM_PROMPT
+from .agent import Agent
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 
-class MistralAgent:
-    def __init__(self, profile: dict):
-        self.model = "open-mixtral-8x22b"
+class MistralAgent(Agent):
+    def __init__(self, profile: dict[str, Union[str, int]], model: str = "open-mixtral-8x22b", tool_only: bool = True):
+        self.model = model
+        super().__init__(profile, ChatMessage)
         self.client = MistralClient(api_key=os.environ.get("MISTRAL_API_KEY"))
-        self.tool_aggregator = ToolAggregator(
-            [
-                CVEditorTool(first_name=profile["first_name"], last_name=profile["last_name"]),
-                IndeedScraperTool(),
-            ]
-        )
-        self.messages = [
-            ChatMessage(role="system", content=SYSTEM_PROMPT),
-            ChatMessage(role="system", content=json.dumps(profile)),
-            ChatMessage(role="assistant", content=START_CHAT_PROMPT),
-        ]
-        self.tokens_used = 0
-        self.max_tool_calls = 5
-        self.profile = profile
+        self.tool_choice = "auto"
+        if tool_only:
+            self.tool_aggregator.tools.append(TalkTool())
+            self.tool_choice = "any"
 
-    def _message_model(self):
+    def serialize_messages(self) -> list[dict[str, str]]:
+        return [message.model_dump() for message in self.messages]
+
+    def unserialize_messages(self, messages: list[dict[str, str]]) -> None:
+        self.messages = [ChatMessage(**message) for message in messages]
+
+    def _message_model(self) -> ChatMessage:
         response = self.client.chat(
             model=self.model,
             messages=self.messages,
             tools=self.tool_aggregator.get_tools(),
-            tool_choice="auto",
-            temperature=0,
+            tool_choice=self.tool_choice,
+            temperature=0.4,
         )
         message = response.choices[0].message
         try:
@@ -49,73 +45,26 @@ class MistralAgent:
         self.tokens_used += response.usage.total_tokens
         return message
 
-    def chat(self, user_input):
+    def chat(self, user_input: str):
         self.messages.append(ChatMessage(role="user", content=user_input))
         message = self._message_model()
         tool_calls = 0
 
-        def is_waiting_for_user_message():
+        def is_waiting_for_user_message() -> bool:
             return not (bool(hasattr(message, "tool_calls") and message.tool_calls is not None) and tool_calls <= self.max_tool_calls)
 
-        yield message, is_waiting_for_user_message()
+        yield message.model_dump(), is_waiting_for_user_message()
         while not is_waiting_for_user_message() and len(message.tool_calls) > 0:
             for tool_call in message.tool_calls:
-                function_name = tool_call.function.name
-                function_params = json.loads(tool_call.function.arguments)
-                function_result = self.tool_aggregator.names_to_functions()[function_name](**function_params)
-                function_result = json.loads(function_result)
-                function_result = {
-                    "name": function_name,
-                    "arguments": str(function_params),
-                    "result": function_result,
-                }
-                function_result = json.dumps(function_result)
-                tool_message = ChatMessage(role="tool", name=function_name, content=function_result)
+                function_result, agent_speaks_next = self.tool_aggregator.names_to_functions()[tool_call.function.name](
+                    args_json=tool_call.function.arguments
+                )
+                tool_message = ChatMessage(role="tool", name=tool_call.function.name, content=function_result)
                 self.messages.append(tool_message)
                 tool_calls += 1
+                if not agent_speaks_next:
+                    yield tool_message.model_dump(), True
+                    return
                 yield tool_message, False
             message = self._message_model()
-            yield message, is_waiting_for_user_message()
-
-    def to_json(self):
-        state = self.__dict__.copy()
-        del state["client"]
-        del state["tool_aggregator"]
-        state["messages"] = [message.dict() for message in state["messages"]]
-        return json.dumps(state)
-
-    @classmethod
-    def from_json(cls, state):
-        state = json.loads(state)
-        state["messages"] = [ChatMessage(**message) for message in state["messages"]]
-        self = cls(state["profile"])
-        self.__dict__.update(state)
-        return self
-
-
-class MistralAgentToolOnly(MistralAgent):
-    def __init__(self, profile):
-        super().__init__(profile)
-        self.tool_aggregator.tools.append(TalkTool())
-
-    def _message_model(self):
-        response = self.client.chat(
-            model=self.model,
-            messages=self.messages,
-            tools=self.tool_aggregator.get_tools(),
-            tool_choice="any",
-            temperature=0.4,
-        )
-        message = response.choices[0].message
-        if message.tool_calls is not None:
-            not_talk_calls = [tool_call for tool_call in message.tool_calls if tool_call.function.name != "talk"]
-            if not len(not_talk_calls):
-                talk_calls = [tool_call for tool_call in message.tool_calls if tool_call.function.name == "talk"]
-                message_content = "\n".join([json.loads(tool_call.function.arguments)["message"] for tool_call in talk_calls])
-                message = ChatMessage(role="assistant", content=message_content)
-            else:
-                message.tool_calls = not_talk_calls
-        self.messages.append(message)
-        self.tokens_used += response.usage.total_tokens
-        print(message)
-        return message
+            yield message.model_dump(), is_waiting_for_user_message()

--- a/aiden_app/static/js/main.js
+++ b/aiden_app/static/js/main.js
@@ -145,7 +145,11 @@ function handleResponse(data) {
         let tokens_used = data.tokens_used;
         updateCounters(tokens_used);
     } else if (message_role == 'tool') {
-        appendMessage(message_role, message_content, false);
+        if (message_content.name == 'talk'){
+            apppendMessage('assistant', message_content.result, false);
+        } else {
+            appendMessage(message_role, message_content, false);
+        }
     } else if (message_role == 'get_profiles') {
         updateProfiles(message_content);
     }

--- a/aiden_app/tools/cv_editor_tool.py
+++ b/aiden_app/tools/cv_editor_tool.py
@@ -1,6 +1,3 @@
-import functools
-import json
-
 from .tool import Tool
 from .utils.cv_editor import CVEdit, CVEditor
 
@@ -8,68 +5,18 @@ from .utils.cv_editor import CVEdit, CVEditor
 class CVEditorTool(Tool):
     def __init__(self, **kwargs):
         self.cv_editor = CVEditor(**kwargs)
-        self.name = 'cvEditorTool'
+        super().__init__("CVEditor")
+        self.add_tool("edit_user_profile", self.edit_user_profile)
 
-    @property
-    def names_to_functions(self):
-        return {
-            'edit_user_profile': functools.partial(self.edit_user_profile),
-        }
-
-    def generate_cv(self, cv_title: str, profile_content_file: str = 'profile_content'):
-        try:
-            self.cv_editor.generate_cv(cv_title, profile_content_file)
-            return json.dumps({'status': 'success'})
-        except Exception as e:
-            return json.dumps({'error': str(e)})
-
-    def edit_profile(self, base_profile: str, new_profile_name: str, edits: list):
-        try:
-            edition_errors = []
-            cv_edits = [CVEdit(path=edit['path'], operation=edit['operation'], value=edit['value']) for edit in edits]
-            for error in self.cv_editor.edit_profile(base_profile, new_profile_name, cv_edits):
-                edition_errors.append(error)
-            return json.dumps({'status': 'success', 'errors': edition_errors})
-        except Exception as e:
-            return json.dumps({'status': 'error', 'errors': [str(e)]})
-
-    def list_profiles(self):
-        try:
-            return json.dumps(self.cv_editor.list_profiles())
-        except Exception as e:
-            return json.dumps({'error': str(e)})
-
-    def get_profile(self, profile_name: str):
-        try:
-            return json.dumps(self.cv_editor.get_profile(profile_name))
-        except Exception as e:
-            return json.dumps({'error': str(e)})
-
-    def list_cvs(self):
-        try:
-            return json.dumps(self.cv_editor.list_cvs())
-        except Exception as e:
-            return json.dumps({'error': str(e)})
-
-    def read_user_profile(self):
-        try:
-            return json.dumps(self.cv_editor.get_profile('default_profile'))
-        except Exception as e:
-            return json.dumps({'error': str(e)})
-
+    @Tool.tool_function
     def edit_user_profile(self, new_profile_name: str, edits: list):
         edition_errors = []
-        try:
-            cv_edits = [CVEdit(path=edit['path'], operation=edit['operation'], value=edit['value']) for edit in edits]
-            for error in self.cv_editor.edit_profile('default_profile', new_profile_name, cv_edits):
-                edition_errors.append(error)
-            pdf_path = self.cv_editor.generate_cv(new_profile_name, new_profile_name)
-            return json.dumps(
-                {
-                    'status': 'success',
-                    'errors': edition_errors,
-                    'document_path': pdf_path,
-                }
-            )
-        except Exception as e:
-            return json.dumps({'status': 'error', 'errors': [str(e)] + edition_errors})
+        cv_edits = [CVEdit(path=edit["path"], operation=edit["operation"], value=edit["value"]) for edit in edits]
+        for error in self.cv_editor.edit_profile("default_profile", new_profile_name, cv_edits):
+            edition_errors.append(error)
+        pdf_path = self.cv_editor.generate_cv(new_profile_name, new_profile_name)
+        return {
+            "status": "success",
+            "errors": edition_errors,
+            "document_path": pdf_path,
+        }

--- a/aiden_app/tools/indeed_scraper_tool.py
+++ b/aiden_app/tools/indeed_scraper_tool.py
@@ -1,58 +1,42 @@
-import functools
-import json
-
-import pandas as pd
-
 from .tool import Tool
 from .utils.indeed_scraper import IndeedScraper
 
 
 class IndeedScraperTool(Tool):
-    @property
-    def names_to_functions(self):
-        return {
-            'search_jobs': functools.partial(self.search_jobs_wrapper),
-            'get_job_details': functools.partial(self.get_job_details_wrapper),
-            'list_job_titles': functools.partial(self.list_job_titles_wrapper),
-        }
-
     def __init__(self):
         self.scraper = IndeedScraper()
-        self.name = 'IndeedScraper'
+        super().__init__("IndeedScraper")
+        self.add_tool("search_jobs", self.search_jobs_wrapper)
+        self.add_tool("get_job_details", self.get_job_details_wrapper)
+        self.add_tool("list_job_titles", self.list_job_titles_wrapper)
 
-    def _format_job_info(self, results: pd.DataFrame) -> str:
+    def _format_job_info(self, results: list) -> str:
         formatted_jobs = []
-        for _, row in results.iterrows():
+        for row in results:
             job = {}
-            job['title'] = row['title']
-            job['company'] = row['company']
-            job['location'] = row['formattedLocation']
-            job['salary'] = row['salarySnippet'].get('text', '')
-            job['job_types'] = ', '.join(row['jobTypes']) if isinstance(row['jobTypes'], list) else ''
-            job['remote_work'] = bool(
-                'remoteWorkModel' in row.keys() and isinstance(row['remoteWorkModel'], dict) and row['remoteWorkModel'].get('inlineText')
+            job["title"] = row["title"]
+            job["company"] = row["company"]
+            job["location"] = row["formattedLocation"]
+            job["salary"] = row["salarySnippet"].get("text", "")
+            job["job_types"] = ", ".join(row["jobTypes"]) if isinstance(row["jobTypes"], list) else ""
+            job["remote_work"] = bool(
+                "remoteWorkModel" in row.keys() and isinstance(row["remoteWorkModel"], dict) and row["remoteWorkModel"].get("inlineText")
             )
             # job['link'] = row['link']
             formatted_jobs.append(job)
         return formatted_jobs
 
+    @Tool.tool_function
     def search_jobs_wrapper(self, search_query: str, location: str, num_results: int = 15, start: int = 0):
-        try:
-            results = pd.DataFrame(self.scraper.search_jobs(search_query, location, int(num_results), int(start)))
-            results = self._format_job_info(results)
-            return json.dumps(results)
-        except Exception as e:
-            return json.dumps({'error': str(e)})
+        results = self.scraper.search_jobs(search_query, location, int(num_results), int(start))
+        results = self._format_job_info(results)
+        return results
 
+    @Tool.tool_function
     def get_job_details_wrapper(self, job_title: str):
-        try:
-            results = self.scraper.get_job_details(job_title)
-            return json.dumps(results)
-        except Exception as e:
-            return json.dumps({'error': str(e)})
+        results = self.scraper.get_job_details(job_title)
+        return results
 
+    @Tool.tool_function
     def list_job_titles_wrapper(self):
-        try:
-            return json.dumps(self.scraper.list_job_titles())
-        except Exception as e:
-            return json.dumps({'error': str(e)})
+        return self.scraper.list_job_titles()

--- a/aiden_app/tools/talk_tool.py
+++ b/aiden_app/tools/talk_tool.py
@@ -1,15 +1,11 @@
-import functools
-
 from .tool import Tool
 
 
 class TalkTool(Tool):
+    def __init__(self):
+        super().__init__("TalkTool")
+        self.add_tool("talk", self.talk, agent_speaks_next=False)
 
-    name = 'talkTool'
-
-    @property
-    def names_to_functions(self):
-        return {'talk': functools.partial(self.talk)}
-
+    @Tool.tool_function
     def talk(self, message):
         return message

--- a/aiden_app/tools/tool.py
+++ b/aiden_app/tools/tool.py
@@ -13,11 +13,11 @@ class Tool(abc.ABC):
 
     def tool_function(func):
         @functools.wraps(func)
-        def wrapper(func_name, agent_speaks_next, args_json):
+        def wrapper(self, func_name, agent_speaks_next, args_json):
             function_params = json.loads(args_json)
             response = {"name": func_name, "arguments": str(function_params)}
             try:
-                result = func(**function_params)
+                result = func(self, **function_params)
                 response["result"] = result
                 return json.dumps(response), agent_speaks_next
             except Exception as e:

--- a/aiden_app/tools/tool.py
+++ b/aiden_app/tools/tool.py
@@ -1,8 +1,27 @@
 import abc
+import functools
+import json
 
 
 class Tool(abc.ABC):
-    @property
-    @abc.abstractmethod
-    def names_to_functions(self):
-        pass
+    def __init__(self, name: str):
+        self.name = name
+        self.names_to_functions = {}
+
+    def add_tool(self, name, function, agent_speaks_next=True):
+        self.names_to_functions[name] = functools.partial(function, func_name=name, agent_speaks_next=agent_speaks_next)
+
+    def tool_function(func):
+        @functools.wraps(func)
+        def wrapper(func_name, agent_speaks_next, args_json):
+            function_params = json.loads(args_json)
+            response = {"name": func_name, "arguments": str(function_params)}
+            try:
+                result = func(**function_params)
+                response["result"] = result
+                return json.dumps(response), agent_speaks_next
+            except Exception as e:
+                response["result"] = {"error": str(e)}
+                return json.dumps(response), agent_speaks_next
+
+        return wrapper


### PR DESCRIPTION
- New `Agent` base class (preparing work for future local llm agents, or other apis like OpenAI agents)
- Unify `MistralAgent` and `MistralAgentToolsOnly` in one class, init params to chose between `tool_choice: any` and `tool_choice: auto` api options
- `tools_function` decorator in `Tool` class to avoid repeating error management and json dumps code. Also allows to simplify a lot the code in `Agent.chat` methods
- Return messages as `dict` and not `ChatMessage` in `views` to allow for different agents than Mistral's
- Management of `talk` action in front end to remove spaghetti code in agent class
- Removed unused tool methods in `IndeedScraperTool`