### PR TITLE
Simpler parser struct

### DIFF
--- a/aiden-recommender/aiden_recommender/models.py
+++ b/aiden-recommender/aiden_recommender/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import BaseModel
 
 
 class Coordinates(BaseModel):
@@ -67,8 +67,7 @@ class JobOffer(BaseModel):
 
     source: str
     reference: str
-    slug: str
-    geoloc: Optional[list[Coordinates]] = Field(None, validation_alias=AliasChoices("_geoloc", "geoloc"))
+    geoloc: Optional[Coordinates] = None
 
     def model_dump(self, *args, **kwargs):
         data = super().model_dump(*args, **kwargs)

--- a/aiden-recommender/aiden_recommender/scrapers/abstract_parser.py
+++ b/aiden-recommender/aiden_recommender/scrapers/abstract_parser.py
@@ -1,5 +1,5 @@
 from aiden_recommender.models import JobOffer
-from aiden_recommender.scrapers.field_extractors import AbstractFieldExtractor
+from aiden_recommender.scrapers.field_extractors import FieldExtractor
 from abc import ABC
 
 
@@ -7,7 +7,7 @@ class AbstractParser(ABC):
     def transform_to_job_offer(self, data) -> JobOffer:
         for field in dir(self):
             extractor = getattr(self, field)
-            if isinstance(extractor, AbstractFieldExtractor):
+            if isinstance(extractor, FieldExtractor):
                 data.update(extractor.extract(data))
         return JobOffer(**data)
 

--- a/aiden-recommender/aiden_recommender/scrapers/abstract_parser.py
+++ b/aiden-recommender/aiden_recommender/scrapers/abstract_parser.py
@@ -8,7 +8,7 @@ class AbstractParser(ABC):
         for field in dir(self):
             extractor = getattr(self, field)
             if isinstance(extractor, AbstractFieldExtractor):
-                data = extractor.extract(data, field)
+                data.update(extractor.extract(data))
         return JobOffer(**data)
 
     def parse(self, data: list) -> list[JobOffer]:

--- a/aiden-recommender/aiden_recommender/scrapers/field_extractors.py
+++ b/aiden-recommender/aiden_recommender/scrapers/field_extractors.py
@@ -1,127 +1,70 @@
 from pydantic import BaseModel
-from abc import ABC, abstractmethod
 import jmespath
-from datetime import datetime
 from pydantic_core import ValidationError
 from loguru import logger
 
 
-class AbstractFieldExtractor(ABC):
+class FieldExtractor:
+    def __init__(
+        self,
+        field: str | list,
+        query: str | list[str] = None,
+        default: any = None,
+        transform_func: callable = None,
+        model: BaseModel = None,
+        nested_fields: list["FieldExtractor"] = [],
+        aggregate_func: callable = None,
+    ) -> None:
+        self.field = field
+        self.query = query
+        self.default = default
+        self.transform_func = transform_func if transform_func else lambda x: x
+        self.model = model
+        self.nested_fields = nested_fields
+        self.aggregate_func = aggregate_func if aggregate_func else lambda x: x
+
     @staticmethod
     def select(data: dict, query: str) -> any:
         if not query:
             return data
         return jmespath.search(query, data)
 
-    @abstractmethod
-    def _extract(self, data: dict) -> any:
-        pass
+    def extract(self, data: dict) -> dict:
+        if isinstance(self.query, list):
+            result = [self.select(data, q) for q in self.query]
+        elif isinstance(self.query, str):
+            result = self.select(data, self.query)
+        elif self.query is None:
+            result = data
+        else:
+            raise ValueError("Query should be string or list of strings")
 
-    @abstractmethod
-    def extract(self, data: dict, field: str) -> dict:
-        pass
+        if self.model:
+            try:
+                if isinstance(result, list):
+                    new_result = []
+                    for item in result:
+                        model_args = {}
+                        for extractor in self.nested_fields:
+                            model_args.update(extractor.extract(item))
+                        new_result.append(self.model(**model_args))
+                    result = new_result
+                else:
+                    model_args = {}
+                    for extractor in self.nested_fields:
+                        model_args.update(extractor.extract(result))
+                    result = self.model(**model_args)
+            except ValidationError as e:
+                logger.warning(f"Error while extracting nested fields: {e}")
+                result = None
 
+        if isinstance(result, list):
+            result = [self.transform_func(item) for item in result]
+            result = self.aggregate_func(result)
+        else:
+            result = self.transform_func(result)
 
-class FieldExtractorBase(AbstractFieldExtractor):
-    def __init__(self, query: str, default: any = None, transform_func: callable = None) -> None:
-        self.query = query
-        self.default = default
-        self.transform_func = transform_func if transform_func else lambda x: x
+        if isinstance(self.field, list):
+            return {field: value for field, value in zip(self.field, result)}
 
-    def _extract(self, data: dict, query=None) -> any:
-        query = query if query is not None else self.query
-        result = self.select(data, query)
-        return self.transform_func(result) if result is not None else self.default
-
-    def extract(self, data, field):
-        result = self._extract(data)
-        data[field] = result
-        return data
-
-
-class NestedFieldExtractor(AbstractFieldExtractor):
-    def __init__(self, model: BaseModel, nested_fields: dict[str, AbstractFieldExtractor]) -> None:
-        self.model = model
-        self.nested_fields = nested_fields
-
-    def _extract(self, data: dict) -> any:
-        try:
-            return self.model(**{field: extractor._extract(data) for field, extractor in self.nested_fields.items()})
-        except ValidationError as e:
-            logger.warning(f"Error while extracting nested fields: {e}")
-            return None
-
-    def extract(self, data, field):
-        data[field] = self._extract(data)
-        return data
-
-
-class MultipleFieldsExtractor(AbstractFieldExtractor):
-    def __init__(self, fields: list[str], extract_func, **kwargs) -> None:
-        self.fields = fields
-        self.extract_func = extract_func
-        self.kwargs = kwargs
-
-    def _extract(self, data: dict) -> any:
-        result = self.extract_func(data, **self.kwargs)
-        if len(result) != len(self.fields):
-            raise ValueError("Length of fields and result should be the same")
-        return {field: value for field, value in zip(self.fields, result)}
-
-    def extract(self, data, field):
-        result = self._extract(data)
-        for field, value in zip(self.fields, result):
-            data[field] = value
-        return data
-
-
-class FromMultipleFieldExtractor(FieldExtractorBase):
-    def __init__(self, queries: list[str], **kwargs) -> None:
-        self.queries = queries
-        self.aggregate_func = kwargs.get("aggregate_func", lambda x: x)
-        kwargs.setdefault("query", None)
-        super().__init__(**kwargs)
-
-    def _extract(self, data: dict) -> any:
-        results = [super()._extract(data, query) for query in self.queries]
-        results = [result for result in results if result is not None]
-        return self.aggregate_func(results)
-
-
-class FieldExtractorConstant(FieldExtractorBase):
-    def __init__(self, value: any) -> None:
-        self.value = value
-
-    def _extract(self, data: dict) -> any:
-        return self.value
-
-
-class DateFieldExtractor(FieldExtractorBase):
-    def __init__(self, query: str, format: str, **kwargs) -> None:
-        self.format = format
-        super().__init__(query, **kwargs)
-
-    @staticmethod
-    def parse_date(date: str, format: str) -> str:
-        return datetime.strptime(date, format).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    def _extract(self, data: dict) -> any:
-        result = super()._extract(data)
-        return self.parse_date(result, self.format)
-
-
-class ListFieldExtractor(AbstractFieldExtractor):
-    def __init__(self, query: str, field_extractor: AbstractFieldExtractor) -> None:
-        self.query = query
-        self.field_extractor = field_extractor
-
-    def _extract(self, data: dict) -> any:
-        result = self.select(self.query, data)
-        if not isinstance(result, list):
-            result = [result]
-        return [self.field_extractor._extract(item) for item in result]
-
-    def extract(self, data, field):
-        result = self._extract(data)
-        data[field] = result
-        return data
+        return {self.field: result}

--- a/aiden-recommender/aiden_recommender/scrapers/field_extractors.py
+++ b/aiden-recommender/aiden_recommender/scrapers/field_extractors.py
@@ -61,8 +61,11 @@ class FieldExtractor:
         if isinstance(result, list):
             result = [self.transform_func(item) for item in result]
             result = self.aggregate_func(result)
-        else:
+        elif result is not None:
             result = self.transform_func(result)
+
+        if result is None or result == "" or result == [] or result == {} or result == data:
+            result = self.default
 
         if isinstance(self.field, list):
             return {field: value for field, value in zip(self.field, result)}

--- a/aiden-recommender/aiden_recommender/scrapers/france_travail/parser.py
+++ b/aiden-recommender/aiden_recommender/scrapers/france_travail/parser.py
@@ -1,6 +1,8 @@
 from aiden_recommender.scrapers.abstract_parser import AbstractParser
 from aiden_recommender.scrapers.field_extractors import FieldExtractor
 from aiden_recommender.models import Coordinates, Office, Organization, Profession
+from aiden_recommender.constants import ISO_8601
+from datetime import datetime
 import jmespath
 import re
 
@@ -46,6 +48,10 @@ def parse_experience_level(experience_level):
         return experience_level
 
 
+def parse_published_at(published_at):
+    return datetime.strptime(published_at, "%Y-%m-%dT%H:%M:%S.%fZ").strftime(ISO_8601)
+
+
 class FranceTravailParser(AbstractParser):
     source = FieldExtractor("source", default="france_travail")
     geoloc = FieldExtractor(
@@ -64,6 +70,7 @@ class FranceTravailParser(AbstractParser):
             FieldExtractor("country", default="France"),
             FieldExtractor("local_city", query="libelle", transform_func=parse_local_city),
         ],
+        transform_func=lambda x: [x],
     )
     organization = FieldExtractor(
         "organization",
@@ -86,7 +93,7 @@ class FranceTravailParser(AbstractParser):
         ["salary_minimum", "salary_maximum", "salary_period"],
         transform_func=parse_salary,
     )
-    published_at = FieldExtractor("published_at", query="dateCreation", format="%Y-%m-%dT%H:%M:%S.%fZ")
+    published_at = FieldExtractor("published_at", query="dateCreation", transform_func=parse_published_at)
     experience_level_minimum = FieldExtractor("experience_level_minimum", query="experienceLibelle", transform_func=parse_experience_level)
     contract_type = FieldExtractor("contract_type", query="typeContratLibelle")
     education_level = FieldExtractor("education_level", query="experienceLibelle")

--- a/aiden-recommender/aiden_recommender/scrapers/wtj/parser.py
+++ b/aiden-recommender/aiden_recommender/scrapers/wtj/parser.py
@@ -1,5 +1,5 @@
 from aiden_recommender.scrapers.abstract_parser import AbstractParser
-from aiden_recommender.scrapers.field_extractors import FieldExtractorBase as feb
+from aiden_recommender.scrapers.field_extractors import FieldExtractor
 
 
 def parse_url(data):
@@ -9,6 +9,6 @@ def parse_url(data):
 
 
 class WtjParser(AbstractParser):
-    source = "wtj"
-    url = feb(query=None, transform_func=parse_url)
-    geoloc = feb(query="_geloc", transform_func=lambda x: x[0])
+    source = FieldExtractor("source", default="wtj")
+    url = FieldExtractor("url", transform_func=parse_url)
+    geoloc = FieldExtractor("geoloc", query="_geoloc", aggregate_func=lambda x: x[0])


### PR DESCRIPTION
@ArthTanc this is  a proposition of a different design for the parser class, taking into accounts your latest review.
- Only one `FieldExtractor` class to rule them all. 
- No more `extract` / `_extract` shenanigans
- No more renaming classes to obscure shortened versions

Positive:
- Probably easier to start using the extractor class

Negative
- Probably harder to understand / predict / change the behavior of the extractor class
- A bit more verbose in the child parser impementations

Not sure what you meant by "simply have a add_field function or something similar that given a field and an extractor it adds an entry to the data dict ?". I was not able to improve on the `dir` + type check implementation. Agree it is dirty though